### PR TITLE
Rewrite the plugin to use pre-existing keychains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 *.p12
+.vscode
 
 # TODO: Remove once not testing
-imp-ci
+imp-ci*

--- a/README.md
+++ b/README.md
@@ -4,6 +4,41 @@ This allows us to perform the actual codesigning steps necessary to release MacO
 
 See [here](https://brevi.link/design-code-signing) for the general design that this fits into.
 
-## Example use
+## Overview
 
-TODO
+This plugin relies upon the build agent already having the necessary keychains created on the machine.
+
+Unfortunately, this is a necessity due to macos' insistence upon a one-time-per-key/keychain manual
+intervention to approve access to the signing key before `codesign` can use it (even if the cert/key are imported with `codesign` pre-granted access to use it).
+
+## Example use TODO(seanrobertson)
+
+```yaml
+- label: "sign-macos-binary"
+  command: "" # No command needed here, since the `command` hook does the work.
+  agents:
+    - "queue=macos-codesigner"
+  artifact_paths: "signed-thing.bin"
+  plugins:
+    - mac-codesign#v1.0.0:
+        input_artifact: "unsigned-thing.bin"
+        keychain: "production-certs.keychain"
+        keychain_secret: "secret/sync.v1/dev-workflow/production-buildkite/buildkite-agents/cert-decryption-password/ci/improbable/production-codesigning"
+```
+
+### Implementation Details
+
+This plugin defines hooks for `environment`, `checkout`, `command`, and `post-command` which execute in that order.
+
+- `environment` performs pre-execution setup and validation before we can actually perform code signing.  It's mostly responsible for checking that the machine in question is allowed to run codesigning jobs.
+
+- `checkout` just disables checkout, since the plugin doesn't need a repo.
+
+- `command` does the main work:
+  - Fetches the artifact to sign from the BK artifact store.
+  - Fetches the keychain unlock secret from Vault
+  - Unlocks the signing keychain.
+  - Signs the binary using the cert in the now-unlocked keychain.
+  - Validates the signature.
+
+- `post-command` just locks the keychain, regardless of how the rest of the job went.

--- a/README.md
+++ b/README.md
@@ -11,19 +11,65 @@ This plugin relies upon the build agent already having the necessary keychains c
 Unfortunately, this is a necessity due to macos' insistence upon a one-time-per-key/keychain manual
 intervention to approve access to the signing key before `codesign` can use it (even if the cert/key are imported with `codesign` pre-granted access to use it).
 
-## Example use TODO(seanrobertson)
+## Example use cases
+
+Using the `KEYCHAIN_PW` env var:
 
 ```yaml
 - label: "sign-macos-binary"
   command: "" # No command needed here, since the `command` hook does the work.
   agents:
     - "queue=macos-codesigner"
-  artifact_paths: "signed-thing.bin"
+  artifact_paths:
+    - "thing.bin_signed"
+    - "another-thing.bin_signed"
   plugins:
     - mac-codesign#v1.0.0:
-        input_artifact: "unsigned-thing.bin"
+        input_artifacts:
+          - "thing.bin"
+          - "another-thing.bin"
         keychain: "production-certs.keychain"
-        keychain_secret: "secret/sync.v1/dev-workflow/production-buildkite/buildkite-agents/cert-decryption-password/ci/improbable/production-codesigning"
+  env:
+        KEYCHAIN_PW: "KeychainPasswordGoesHere"
+```
+
+Using the default Improbable secret-fetching script with `keychain_pw_secret_name` set:
+
+```yaml
+- label: "sign-macos-binary"
+  command: "" # No command needed here, since the `command` hook does the work.
+  agents:
+    - "queue=macos-codesigner"
+  artifact_paths:
+    - "thing.bin_signed"
+    - "another-thing.bin_signed"
+  plugins:
+    - mac-codesign#v1.0.0:
+        input_artifacts:
+          - "thing.bin"
+          - "another-thing.bin"
+        keychain: "production-certs.keychain"
+        keychain_pw_secret_name: "ci/improbable/production-codesigning"
+```
+
+Using a custom secret-fetching script:
+
+```yaml
+- label: "sign-macos-binary"
+  command: "" # No command needed here, since the `command` hook does the work.
+  agents:
+    - "queue=macos-codesigner"
+  artifact_paths:
+    - "thing.bin_signed"
+    - "another-thing.bin_signed"
+  plugins:
+    - mac-codesign#v1.0.0:
+        input_artifacts:
+          - "thing.bin"
+          - "another-thing.bin"
+        keychain: "production-certs.keychain"
+        keychain_pw_helper_script: "~/fetch-keychain-pw.sh"
+        keychain_pw_secret_name: "production-codesigning-keychain-pw"
 ```
 
 ### Implementation Details
@@ -36,9 +82,26 @@ This plugin defines hooks for `environment`, `checkout`, `command`, and `post-co
 
 - `command` does the main work:
   - Fetches the artifact to sign from the BK artifact store.
-  - Fetches the keychain unlock secret from Vault
+    - This can be any one-or-more artifacts created in the same pipeline as this step, and then stored in the BK artifact store.
   - Unlocks the signing keychain.
   - Signs the binary using the cert in the now-unlocked keychain.
   - Validates the signature.
 
 - `post-command` just locks the keychain, regardless of how the rest of the job went.
+
+#### Keychain unlocking
+
+Since your signing cert needs to be stored in a keychain, and that keychain is assumed to be locked, we
+need a password to unlock the signing keychain.
+
+There are two ways to supply a keychain unlocking password to this plugin:
+
+1. In the simple case, you can set the environment variable `KEYCHAIN_PW` on your step.
+1. If `KEYCHAIN_PW` is not set, the command hook will call a helper script, which needs to export your keychain unlock password as `KEYCHAIN_PW` - eg:
+
+    - ```bash
+      export KEYCHAIN_PW="foo-bar-123"
+      ```
+
+    - If you use a secret store like Vault, you should supply the path to your own helper script to retrieve the secret.  By default, the plugin will use `$HOOKS_DIR/helpers/fetch-keychain-pw.sh`, but you can override this with the `keychain_pw_helper_script` parameter.  
+    - If set, `keychain_pw_secret_name` will be available to the helper script, which can be used to supply a name or path for a specific secret to retrieve.

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# This just makes this job not do a checkout.  It's not needed, so why do it?
 
 set -euo pipefail
 

--- a/hooks/command
+++ b/hooks/command
@@ -1,29 +1,58 @@
 #!/usr/bin/env bash
 #
-# Now that we have a constructed codesigning environment, sign the code.
+# Now that we have a valid codesigning environment, sign the code.
+# 1. Retrieve the unsigned binary from the BK artifact store
+# 2. Retrieve the keychain unlock password from Vault
+# 3. Unlock the keychain
+# 4. Sign the binary and validate the signature
 
 [[ -n "${DEBUG-}" ]] && set -x
 
-artifact_dir=$(mktemp -d)
-### TESTING
-cp imp-ci "${artifact_dir}"
-signing_target=$(ls -1 "${artifact_dir}")
-### TESTING
-pushd "${artifact_dir}"
+target_artifact="${BUILDKITE_PLUGIN_MAC_CODESIGN_INPUT_ARTIFACT}"
+codesign_keychain="${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN}"
+keychain_pw_path="${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN_SECRET}"
 
+# Fetch the artifact and put it in the right place
 echo "Retrieving unsigned artifact"
-buildkite-agent artifact download "${BUILDKITE_PLUGIN_MAC_CODESIGN_INPUT_ARTIFACT}" .
+signing_target="$(pwd)/$(ls ${target_artifact})"
+buildkite-agent artifact download "${target_artifact}" .
 retval=$?
 if [[ "${retval}" -ne 0  ]]; then
-  echo "Unable to download the specified artifact '${BUILDKITE_PLUGIN_MAC_CODESIGN_INPUT_ARTIFACT}' with error code '${retval}'"
+  echo "Unable to download the specified artifact '${target_artifact}' with error code '${retval}'"
   exit 1
 fi
 
-# echo "Unlock the keychain"
-# security unlock-keychain -p "${KEYCHAIN_PW}" codesign.keychain
+# Remove this block once we're ready to start actually testing this in CI.
+### TESTING
+signing_target="$(pwd)/imp-ci"
+cp imp-ci-orig "${signing_target}"
+### TESTING
 
+# Get the keychain password from Vault, unlock the keychain, and find the identity to sign with
+echo "Retrieving password for signing cert"
+keychain_pw=$(imp-vault read-key --key="${pw_secret}" --field=token)
+if [[ $? -ne 0 || "${keychain_pw}" == "" ]]; then
+  echo "Unable to read secret for specified secret ${pw_secret}"
+  exit 1
+else
+  echo "Successfully read secret from Vault"
+fi
+
+echo "Unlock the keychain"
+security unlock-keychain -p "${keychain_pw}" "${codesign_keychain}"
+retval=$?
+if [[ "${retval}" -ne 0  ]]; then
+  echo "Unable to unlock the requested keychain '${codesign_keychain}' with error code '${retval}'"
+  exit 1
+fi
+
+echo "Find the code signing identity in the newly unlocked keychain"
+# This is awful, but we need to get some portion of the identity out of the keychain, and there's no clean way to do it.
+export CODESIGN_IDENTITY="$(security find-identity ${codesign_keychain} | grep -A1 "Valid identities" | tail -1 | awk '{print $2}')"
+
+# Sign the binary
 echo "Signing target binary"
-codesign --verify --verbose --display --deep -s "${CODESIGN_IDENTITY}" ${signing_target}
+codesign --verify --verbose --display --deep -s "${CODESIGN_IDENTITY}" "${signing_target}"
 retval=$?
 if [[ "${retval}" -ne 0  ]]; then
   echo "codesigning of target '${signing_target}' failed with error code '${retval}'"
@@ -36,12 +65,4 @@ retval=$?
 if [[ "${retval}" -ne 0  ]]; then
   echo "Unable to verify that '${signing_target}' has a valid code signature: error code '${retval}'"
   exit 3
-fi
-
-echo "Uploading signed artifact"
-buildkite-agent artifact upload "${BUILDKITE_PLUGIN_MAC_CODESIGN_INPUT_ARTIFACT}" "${output_artifact}"
-retval=$?
-if [[ "${retval}" -ne 0  ]]; then
-  echo "Unable to upload signed artifact '${BUILDKITE_PLUGIN_MAC_CODESIGN_INPUT_ARTIFACT}' to artifact bucket with error code '${retval}'"
-  exit 4
 fi

--- a/hooks/command
+++ b/hooks/command
@@ -10,11 +10,13 @@
 
 target_artifact="${BUILDKITE_PLUGIN_MAC_CODESIGN_INPUT_ARTIFACT}"
 codesign_keychain="${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN}"
-keychain_pw_path="${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN_SECRET}"
+keychain_pw_name="${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN_PW_SECRET_NAME}"
+keychain_pw_helper="./helpers/fetch-keychain-pw.sh"
+script_root_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Fetch the artifact and put it in the right place
 echo "Retrieving unsigned artifact"
-signing_target="$(pwd)/$(ls ${target_artifact})"
+signing_target="$(pwd)/${target_artifact}"
 buildkite-agent artifact download "${target_artifact}" .
 retval=$?
 if [[ "${retval}" -ne 0  ]]; then
@@ -28,18 +30,19 @@ signing_target="$(pwd)/imp-ci"
 cp imp-ci-orig "${signing_target}"
 ### TESTING
 
-# Get the keychain password from Vault, unlock the keychain, and find the identity to sign with
-echo "Retrieving password for signing cert"
-keychain_pw=$(imp-vault read-key --key="${pw_secret}" --field=token)
-if [[ $? -ne 0 || "${keychain_pw}" == "" ]]; then
-  echo "Unable to read secret for specified secret ${pw_secret}"
-  exit 1
-else
-  echo "Successfully read secret from Vault"
+# If the unlock secret was not supplied as an env var, call the helper script to fetch it
+if [[ -z "${KEYCHAIN_PW}" ]]; then
+  "$(${script_root_dir}/${keychain_pw_helper} ${keychain_pw_name})"
+  retval=$?
+  if [[ "${retval}" -ne 0 || -z "${KEYCHAIN_PW}"  ]]; then
+    echo "Unable the fetch the secret using the helper script with error code '${retval}'"
+    exit 1
+  fi
 fi
 
+# Now unlock the keychain and find the identity to sign with
 echo "Unlock the keychain"
-security unlock-keychain -p "${keychain_pw}" "${codesign_keychain}"
+security unlock-keychain -p "${KEYCHAIN_PW}" "${codesign_keychain}"
 retval=$?
 if [[ "${retval}" -ne 0  ]]; then
   echo "Unable to unlock the requested keychain '${codesign_keychain}' with error code '${retval}'"
@@ -66,3 +69,5 @@ if [[ "${retval}" -ne 0  ]]; then
   echo "Unable to verify that '${signing_target}' has a valid code signature: error code '${retval}'"
   exit 3
 fi
+
+mv "${signing_target}" "${signing_target}_signed"

--- a/hooks/environment
+++ b/hooks/environment
@@ -28,7 +28,7 @@ if [[ "${BUILDKITE_SOURCE}" == "local" ]]; then
 fi
 
 if [[ "${BUILDKITE_AGENT_META_DATA_PLATFORM}" != "macos" ]]; then
-  echo "Code signing can only be performed on macos."
+  echo "Code signing of macOS binaries can only be performed on macos."
   exit 4
 fi
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -1,104 +1,38 @@
 #!/usr/bin/env bash
 #
-# This script sets up the environment needed to perform code signing.
-# 0. Ensure that this job is allowed to proceed with codesigning stuff.
-# 1. Find the signing cert on disk.
-# 2. Get the password to decrypt it from Vault.
-# 3. Create a temporary keychain, import the signing cert into it, then lock the keychain with a rand pw.
-# 4. Export the codesigning identity ID and the keychain password so the rest of this job can sign with them.
+# This script validates the environment needed to perform code signing.
+# 1. Ensure that the requested keychain exists
+# 2. Validate that this job is allowed to proceed with codesigning tasks.
 
 [[ -n "${DEBUG-}" ]] && set -x
 
-signing_cert_name="${BUILDKITE_PLUGIN_MAC_CODESIGN_SIGNING_CERT}"
-pw_secret="${BUILDKITE_PLUGIN_MAC_CODESIGN_SIGNING_CERT_PW_SECRET}"
-
-cert_store_root_path="/Users/buildkite-agent/signing-certs"
 # TODO: Make this be the actual signing host, not my laptop.
 permitted_signing_host="sean-mac-c02xv3a8jgh6"
-codesign_keychain="${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN:-codesign.keychain}"
-cert_pw=""
-signing_cert_path="${cert_store_root_path}/${signing_cert_name}"
+codesign_keychain="${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN}"
+pw_secret="${BUILDKITE_PLUGIN_MAC_CODESIGN_SIGNING_CERT_PW_SECRET}"
+
+if [[ ! security list-keychains ]]; then
+  echo "Unable to find/read specified signing keychain ${codesign_keychain}"
+  exit 1
+fi
 
 # Verify that this is only running on MacOS, via BuildKite, in proper CI, on our blessed agent.
-validate_environment() {
-  if [[ ! -r "${signing_cert_path}" ]]; then
-    echo "Unable to find/read specified signing cert ${signing_cert} in ${cert_store_root_path}"
-    exit 1
-  else
-    echo "Found cert!"
-  fi
+if [[ "${BUILDKITE}" != "true" ]]; then
+  echo "Code signing can only be done as part of a BuildKite pipeline."
+  exit 2
+fi
 
-  if [[ "${BUILDKITE}" != "true" ]]; then
-    echo "Code signing can only be done as part of a BuildKite pipeline."
-    exit 2
-  fi
+if [[ "${BUILDKITE_SOURCE}" == "local" ]]; then
+  echo "Code signing is not allowed to be done locally."
+  exit 3
+fi
 
-  if [[ "${BUILDKITE_SOURCE}" == "local" ]]; then
-    echo "Code signing is not allowed to be done locally."
-    exit 3
-  fi
+if [[ "${BUILDKITE_AGENT_META_DATA_PLATFORM}" != "macos" ]]; then
+  echo "Code signing can only be performed on macos."
+  exit 4
+fi
 
-  if [[ "${BUILDKITE_AGENT_META_DATA_PLATFORM}" != "macos" ]]; then
-    echo "Code signing can only be performed on macos."
-    exit 4
-  fi
-
-  if [[ "${BUILDKITE_AGENT_META_DATA_HOSTNAME}" != "${permitted_signing_host}" ]]; then
-    echo "Code signing can only be performed on specific permitted agents."
-    exit 5
-  fi
-}
-
-# Required param: 
-#   name of the secret to retrieve from Vault
-retrieve_signing_cert_pw() {
-  echo "Retrieving password for signing cert"
-  cert_pw=$(imp-vault read-key --key="${1}" --field=token)
-  if [[ $? -ne 0 || "${cert_pw}" == "" ]]; then
-    echo "Unable to read secret for specified secret ${1}"
-    exit 1
-  else
-    echo "Successfully read secret from Vault"
-  fi
-}
-
-# Required param: 
-#   name of the keychain to create
-create_codesign_keychain() {
-  echo "Setting up temporary codesigning keychain"
-  # Randomly generate a secure pw for the keychain.
-  export KEYCHAIN_NAME="${1}"
-  export KEYCHAIN_PW="$(head /dev/urandom | LC_ALL=C tr -dc A-Za-z0-9 | head -c 16)"
-  
-  # If the keychain already exists, warn the user and then delete it so we start fresh.
-  security list-keychains | grep "${1}"
-  if [[ $? -eq 0  ]]; then
-    echo "WARNING: The keychain ${1} already exists.  Removing it and creating a new empty keychain."
-    security delete-keychain "${1}"
-  fi
-  
-  # Now create the keychain and add it to the search list.  create-keychain claims to do this, but it lies.
-  security create-keychain -p "${KEYCHAIN_PW}" "${1}"
-  security list-keychains -d user -s login.keychain "${1}"
-}
-
-# Required params: 
-#   Path to the certificate to be added.
-#   Name of the keychain to add to.
-#   Password to decrypt the certificate.
-add_certificate_to_keychain() {
-  echo "Adding cert to keychain"
-  # '-T' allows codesign to use this cert without requiring further password input.
-  security import "${1}" -k "${2}" -P "${cert_pw}" -T /usr/bin/codesign
-  
-  # Ugh, this is so awful, but we need to get some portion of the identity out of the keychain, and there's no clean way to do it.
-  export CODESIGN_IDENTITY="$(security find-identity codesign.keychain | grep -A1 "Valid identities" | tail -1 | awk '{print $2}')"
-  
-  # Lock it up, juuuuust in case.
-  # security lock-keychain "${2}"
-}
-
-validate_environment
-retrieve_signing_cert_pw "${pw_secret}"
-create_codesign_keychain "${codesign_keychain}"
-add_certificate_to_keychain "${signing_cert_path}" "${codesign_keychain}" "${cert_pw}"
+if [[ "${BUILDKITE_AGENT_META_DATA_HOSTNAME}" != "${permitted_signing_host}" ]]; then
+  echo "Code signing can only be performed on specific permitted agents."
+  exit 5
+fi

--- a/hooks/helpers/fetch-keychain-pw.sh
+++ b/hooks/helpers/fetch-keychain-pw.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# If required, this script fetches a secret from Improbable's Vault
+# using our imp-ci tool and sticks it in an ENV var for consumption
+
+# All decryption password secrets must live under this path
+keychain_pw_root="secret/sync.v1/dev-workflow/production-buildkite/buildkite-agents/cert-decryption-password/"
+keychain_pw_name="${1}"
+keychain_pw_path="${keychain_pw_root}/${keychain_pw_name}"
+
+# Get the keychain password from Vault
+echo "Retrieving password for signing cert"
+keychain_pw=$(imp-vault read-key --key="${pw_secret}" --field=token)
+if [[ $? -ne 0 || "${keychain_pw}" == "" ]]; then
+  echo "Unable to read specified secret ${pw_secret}"
+  exit 1
+else
+  export KEYCHAIN_PW="${keychain_pw}"
+fi

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -12,7 +12,7 @@ security lock-keychain "${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN}"
 
 if [[ $? -ne 0 ]]; then
   # TODO: This needs to be able to actually alert us directly if it happens.
-  # We'll find a way to do that eventually.
   echo "ERROR: Unable to lock codesigning keychain!"
   echo "This can be extremely serious!  Let #eng-velocity know right away!"
+  exit 5 # Arbitrary error exit code for this specific condition.
 fi

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 #
-# Just remove the temporary keychain created at the start.
+# Lock the keychain we used to sign things.
 
 [[ -n "${DEBUG-}" ]] && set -x
 
-security delete-keychain "${KEYCHAIN_NAME}"
+# Clean up the unsigned artifact
+rm -f "${BUILDKITE_PLUGIN_MAC_CODESIGN_INPUT_ARTIFACT}"
+
+# And lock the door behind us
+security lock-keychain "${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN}"
 
 if [[ $? -ne 0 ]]; then
-  echo "WARNING: Unable to delete temporary keychain!"
-  # TODO: Obviously this needs to actually alert us directly if it happens.
+  # TODO: This needs to be able to actually alert us directly if it happens.
   # We'll find a way to do that eventually.
+  echo "ERROR: Unable to lock codesigning keychain!"
   echo "This can be extremely serious!  Let #eng-velocity know right away!"
 fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -4,19 +4,18 @@ description: "Apply code signatures to MacOS binaries"
 author: https://github.com/DoomGerbil
 # TODO: Discover and list requirements
 requirements:
-  - imp-vault
   - security
   - codesign
-# TODO: Flesh out configuration options
 configuration:
   properties:
-    input_artifact:
-      type: string
+    input_artifacts:
+      type: [ string, array ]
     keychain:
       type: string
-    keychain_secret:
+    keychain_pw_secret_name:
+      type: string
+    keychain_pw_helper_script:
       type: string
   required:
     - input_artifact
     - keychain
-    - keychain_secret

--- a/plugin.yml
+++ b/plugin.yml
@@ -5,19 +5,18 @@ author: https://github.com/DoomGerbil
 # TODO: Discover and list requirements
 requirements:
   - imp-vault
+  - security
+  - codesign
 # TODO: Flesh out configuration options
 configuration:
   properties:
     input_artifact:
       type: string
-    output_artifact:
+    keychain:
       type: string
-    signing_cert:
-      type: string
-    signing_cert_pw_secret:
+    keychain_secret:
       type: string
   required:
     - input_artifact
-    - output_artifact
-    - signing_cert
-    - signing_cert_pw_secret
+    - keychain
+    - keychain_secret


### PR DESCRIPTION
This is a pretty substantial rewrite of the core plugin logic.  Note that it's not yet end-to-end tested - I'm doing that now, and this PR is for visibility.

There are still some testing-related bits present - I'll rip those out once I've been able to verify things locally.

The core change is that:

Previously, each invocation would create a temporary keychain, fetch a cert password from vault, import the designated cert into that keychain, then use it to sign the binary, and delete the temporary keychain.

Now, each invocation uses a pre-existing but locked keychain on the agent.  It fetches a keychain unlock password from Vault, unlocks the keychain, signs the binary, and relocks the keychain.

This should allow us to get around the Apple requirement that there be human-driven physical approval the first time a private key in a keychain is used to sign a thing.

Unfortunately, this means that now, we have to make several assumptions about the state of the agent before signing can happen:
1. A keychain with the supplied name exists on the signing agent.
1. That keychain contains ONLY the signing cert and the private key for using that cert to sign a binary.
1. That keychain has been manually used at least one time to sign a binary since it was created.

So all of these steps must be done manually for each keychain we want to use, before we are able to use it. 
