### PR TITLE
Now fully working end to end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
 .DS_Store
 *.p12
 .vscode
-
-# TODO: Remove once not testing
-imp-ci*

--- a/README.md
+++ b/README.md
@@ -1,10 +1,29 @@
 # MacOS Code Signing Plugin
 
-This allows us to perform the actual codesigning steps necessary to release MacOS software.
+## Overview
+
+This plugin performs the actual codesigning steps necessary to release MacOS software.
 
 See [here](https://brevi.link/design-code-signing) for the general design that this fits into.
+TODO(@DoomGerbil): Make this design doc visible to people outside of Improbable.
 
-## Overview
+### Features
+
+- Signs binaries, dmgs, pkgs, or apps for MacOS.
+- One or more targets can be specified for signing at once.
+- Automatic unlocking/locking of signing keychains.
+- Secrets for unlocking signing certs can be supplied as env vars or fetched from external secret storage (eg Vault).
+- Prevents signing jobs from being run on unapproved machines, or using unsafe workflows.
+
+### Limitations/Caveats
+
+- This does not presently do any notarization.
+- No support for iOS signing workflows.
+- You must have the certificate to use already set up on the agent.
+- Each certificate and matching private key should be in a separate keychain on the agent.
+  - This requires that you have _used the certificate_ to sign a binary once, on the agent.
+  - And selected the "Approve Always" button when macos presented a keychain access dialog.
+    - Otherwise macos requires human intervention to use the key to sign.
 
 This plugin relies upon the build agent already having the necessary keychains created on the machine.
 
@@ -17,14 +36,12 @@ Using the `KEYCHAIN_PW` env var:
 
 ```yaml
 - label: "sign-macos-binary"
-  command: "" # No command needed here, since the `command` hook does the work.
   agents:
     - "queue=macos-codesigner"
   plugins:
     - mac-codesign#v1.0.0:
         input_artifacts:
           - "thing.bin"
-          - "another-thing.bin"
         keychain: "production-certs.keychain"
   env:
         KEYCHAIN_PW: "KeychainPasswordGoesHere"
@@ -34,7 +51,6 @@ Using the default Improbable secret-fetching script with `keychain_pw_secret_nam
 
 ```yaml
 - label: "sign-macos-binary"
-  command: "" # No command needed here, since the `command` hook does the work.
   agents:
     - "queue=macos-codesigner"
   plugins:
@@ -50,7 +66,6 @@ Using a custom secret-fetching script:
 
 ```yaml
 - label: "sign-macos-binary"
-  command: "" # No command needed here, since the `command` hook does the work.
   agents:
     - "queue=macos-codesigner"
   plugins:

--- a/helpers/fetch-keychain-pw.sh
+++ b/helpers/fetch-keychain-pw.sh
@@ -4,6 +4,9 @@
 # using our imp-ci tool and sticks it in an ENV var for consumption
 
 # All decryption password secrets must live under this path
+
+[[ -n "${DEBUG-}" ]] && set -x
+
 keychain_pw_root="secret/sync.v1/dev-workflow/production-buildkite/buildkite-agents/cert-decryption-password/"
 keychain_pw_name="${1}"
 keychain_pw_path="${keychain_pw_root}/${keychain_pw_name}"
@@ -14,5 +17,5 @@ if [[ $? -ne 0 || "${keychain_pw}" == "" ]]; then
   echo "Unable to read specified secret ${pw_secret}"
   exit 1
 else
-  export KEYCHAIN_PW="${keychain_pw}"
+  echo "${keychain_pw}"
 fi

--- a/helpers/fetch-keychain-pw.sh
+++ b/helpers/fetch-keychain-pw.sh
@@ -9,8 +9,7 @@ keychain_pw_name="${1}"
 keychain_pw_path="${keychain_pw_root}/${keychain_pw_name}"
 
 # Get the keychain password from Vault
-echo "Retrieving password for signing cert"
-keychain_pw=$(imp-vault read-key --key="${pw_secret}" --field=token)
+keychain_pw=$(imp-vault read-key --key="${keychain_pw_path}" --field=token)
 if [[ $? -ne 0 || "${keychain_pw}" == "" ]]; then
   echo "Unable to read specified secret ${pw_secret}"
   exit 1

--- a/helpers/fetch-keychain-pw.sh
+++ b/helpers/fetch-keychain-pw.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 #
 # If required, this script fetches a secret from Improbable's Vault
-# using our imp-ci tool and sticks it in an ENV var for consumption
-
-# All decryption password secrets must live under this path
+# using our imp-ci tool and echos it to stdout.
 
 [[ -n "${DEBUG-}" ]] && set -x
 
+# All decryption password secrets must live under this path
 keychain_pw_root="secret/sync.v1/dev-workflow/production-buildkite/buildkite-agents/cert-decryption-password/"
 keychain_pw_name="${1}"
 keychain_pw_path="${keychain_pw_root}/${keychain_pw_name}"

--- a/hooks/command
+++ b/hooks/command
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 #
-# Now that we have a valid codesigning environment, sign the code.
+# Actually signs the package.
 # 1. Retrieve the unsigned binary from the BK artifact store
-# 2. Retrieve the keychain unlock password from Vault
+# 2. Retrieve the keychain unlock password
 # 3. Unlock the keychain
 # 4. Sign the binary and validate the signature
+# 5. Upload the binary as a BuildKite artifact
 
 set -e -o pipefail
 [[ -n "${DEBUG-}" ]] && set -x
 
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
-
 # shellcheck source=lib/shared.sh
 source "${DIR}/../lib/shared.sh"
 
@@ -145,20 +145,22 @@ rm -rf "${signed_dir_fragment}" && mkdir -p "${signed_dir_fragment}"
 
 # Download and sign each requested artifact
 for artifact in $(plugin_read_list INPUT_ARTIFACTS) ; do
-  echo "--- ${artifact}: retrieving unsigned artifact"
+  echo "--- Signing ${artifact}"
+
+  echo "${artifact}: retrieving unsigned artifact"
   unsigned_artifact="$(fetch_artifact ${artifact} ${relative_artifacts_dir})"
 
-  echo "--- ${artifact}: signing binary"
+  echo "${artifact}: signing binary"
   signed_artifact="$(sign_and_validate "${unsigned_artifact}" "${identity}")"
 
   # The pushd/popd/dirname/basename shenanigans are so the artifact path in BK is friendlier.  EG - 
   # "signed/$BINARY_NAME"
-  # Otherwise it gets the fully-qualified path to the artifact.  More like:
+  # Otherwise it gets the fully-qualified path to the artifact, like:
   # "usr/local/var/buildkite-agent/builds/macos-codesigner/improbable/platform-mac-codesign-test/signed/imp-ci"
   signed_dir="$(dirname ${signed_artifact})"
   signed_file="$(basename ${signed_artifact})"
   
-  echo "--- ${signed_file}: uploading signed artifact"
+  echo "${signed_file}: uploading signed artifact"
   # Change to the directory containing "signed/", where the artifacts live.
   # This way, the uploaded artifacts in BK will all be named "signed/$BINARY_NAME"
   pushd "${signed_dir}/.."

--- a/hooks/command
+++ b/hooks/command
@@ -91,8 +91,10 @@ function sign_and_validate {
 
 function upload_artifact {
   signed_artifact="${1}"
+  pushd "$(basename ${signed_artifact})"
   buildkite-agent artifact upload "${signed_artifact}"
   retval=$?
+  popd
   if [[ "${retval}" -ne 0  ]]; then
     echo "Unable to upload ${signed_artifact} to BuildKite: error code '${retval}'"
     exit 6

--- a/hooks/command
+++ b/hooks/command
@@ -98,10 +98,7 @@ function sign_and_validate {
     exit 5
   fi
 
-  # Copy the signed binary to where it's expected to be for artifact uploading.
-  signed_artifact="${signing_target}_signed"
-  cp "${signing_target}" "${signed_artifact}"
-  echo "${signed_artifact}"
+  echo "${signing_target}"
 }
 
 # Convenience wrapper to upload our signed artifact to BuildKite
@@ -158,10 +155,13 @@ for artifact in $(plugin_read_list INPUT_ARTIFACTS) ; do
   # "signed/$BINARY_NAME"
   # Otherwise it gets the fully-qualified path to the artifact.  More like:
   # "usr/local/var/buildkite-agent/builds/macos-codesigner/improbable/platform-mac-codesign-test/signed/imp-ci"
-  echo "--- ${signed_artifact}: uploading signed artifact"
   signed_dir="$(dirname ${signed_artifact})/.."
-  signed_artifact="$(basename ${signed_artifact})/.."
+  signed_file="$(basename ${signed_artifact})/.."
+  
+  echo "--- ${signed_file}: uploading signed artifact"
+  # Change to the directory containing "signed/", where the artifacts live.
+  # This way, the uploaded artifacts in BK will all be named "signed/$BINARY_NAME"
   pushd "${signed_dir}/.."
-  upload_artifact "${signed_dir_fragment}/${signed_artifact}"
+  upload_artifact "${signed_dir_fragment}/${signed_file}"
   popd
 done

--- a/hooks/command
+++ b/hooks/command
@@ -20,6 +20,9 @@ script_root_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd
 default_keychain_pw_helper_script="${script_root_dir}/../helpers/fetch-keychain-pw.sh"
 
 # Fetch the artifact and put it in the target dir
+# Params:
+#   fetch_target: Name of the BuildKite artifact to fetch
+#   dest_dir: Where to download it to.
 function fetch_artifact {
   fetch_target="${1}"
   dest_dir="${2}"
@@ -34,6 +37,9 @@ function fetch_artifact {
 }
 
 # If the unlock secret was not supplied as an env var, call the helper script to fetch it
+# Params:
+#   helper_script_path: Path to a script to run that returns the keychain PW.
+#   helper_script_arg: Any arguments that need to be passed to the helper script.
 function get_keychain_pw {
   helper_script_path="${1}"
   helper_script_arg="${2}"
@@ -50,6 +56,9 @@ function get_keychain_pw {
 }
 
 # Now unlock the keychain and find the identity to sign with
+# Params:
+#   keychain_name: The name of an existing, accessible macos Keychain containing one signing certificate.
+#   keychain_pw: The password to unlock this keychain.
 function unlock_keychain {
   keychain_name=${1}
   keychain_pw=${2}
@@ -61,12 +70,16 @@ function unlock_keychain {
   fi
 }
 
+# Convenience wrapper to extract the identity from the cert in the keychain.
+# This is awful, but we need a portion of the identity from the keychain, and there's no clean way to do it.
 function get_signing_identity {
-  # This is awful, but we need to get some portion of the identity out of the keychain, and there's no clean way to do it.
   security find-identity ${codesign_keychain} | grep -A1 "Valid identities" | tail -1 | awk '{print $2}'
 }
 
 # Sign the binary
+# Params:
+#   signing_target: The unsigned item to sign.
+#   identity: The identity to use for signing.
 function sign_and_validate {
   signing_target="${1}"
   identity="${2}"
@@ -91,21 +104,20 @@ function sign_and_validate {
   echo "${signed_artifact}"
 }
 
+# Convenience wrapper to upload our signed artifact to BuildKite
+# Params:
+#   artifact: Path of a file to upload to BuildKite as an artifact.
 function upload_artifact {
-  signed_artifact="${1}"
-  # The pushd/popd/dirname/basename shenanigans are so the artifact path in BK is friendlier
-  # eg "signed/$BINARY_NAME"
-  pushd "$(dirname ${signed_artifact})/.."
-  buildkite-agent artifact upload $(basename ${signed_artifact})
+  artifact="${1}"
+  buildkite-agent artifact upload ${artifact}
   retval=$?
-  popd
   if [[ "${retval}" -ne 0  ]]; then
-    echo "Unable to upload ${signed_artifact} to BuildKite: error code '${retval}'"
+    echo "Unable to upload ${artifact} to BuildKite: error code '${retval}'"
     exit 6
   fi
 }
 
-# If the user set a secret-fetch helper script, use it, otherwise use the default.
+# Allow the user to override the default keychain pw retrieval helper script.
 function find_keychain_pw_helper_script {
   if [[ -n "${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN_PW_HELPER_SCRIPT}" ]]; then
     script="${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN_PW_HELPER_SCRIPT}"
@@ -130,8 +142,9 @@ echo "--- Finding the code signing identity in the unlocked keychain"
 identity=$(get_signing_identity "${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN}")
 
 # Sign things in a local dir so the uploaded artifacts don't have a weird path
-relative_artifacts_dir="$(pwd)/signed"
-rm -rf "${relative_artifacts_dir}" && mkdir -p "${relative_artifacts_dir}"
+signed_dir_fragment="signed"
+relative_artifacts_dir="$(pwd)/${signed_dir_fragment}"
+rm -rf "${signed_dir_fragment}" && mkdir -p "${signed_dir_fragment}"
 
 # Download and sign each requested artifact
 for artifact in $(plugin_read_list INPUT_ARTIFACTS) ; do
@@ -141,6 +154,14 @@ for artifact in $(plugin_read_list INPUT_ARTIFACTS) ; do
   echo "--- ${artifact}: signing binary"
   signed_artifact="$(sign_and_validate "${unsigned_artifact}" "${identity}")"
 
-  echo "--- ${artifact}: uploading signed artifact"
-  upload_artifact "${signed_artifact}"
+  # The pushd/popd/dirname/basename shenanigans are so the artifact path in BK is friendlier.  EG - 
+  # "signed/$BINARY_NAME"
+  # Otherwise it gets the fully-qualified path to the artifact.  More like:
+  # "usr/local/var/buildkite-agent/builds/macos-codesigner/improbable/platform-mac-codesign-test/signed/imp-ci"
+  echo "--- ${signed_artifact}: uploading signed artifact"
+  signed_dir="$(dirname ${signed_artifact})/.."
+  signed_artifact="$(basename ${signed_artifact})/.."
+  pushd "${signed_dir}/.."
+  upload_artifact "${signed_dir_fragment}/${signed_artifact}"
+  popd
 done

--- a/hooks/command
+++ b/hooks/command
@@ -91,7 +91,6 @@ function sign_and_validate {
 
 function upload_artifact {
   signed_artifact="${1}"
-  mv ${signed_artifact})
   buildkite-agent artifact upload "${signed_artifact}"
   retval=$?
   popd

--- a/hooks/command
+++ b/hooks/command
@@ -93,7 +93,6 @@ function upload_artifact {
   signed_artifact="${1}"
   buildkite-agent artifact upload "${signed_artifact}"
   retval=$?
-  popd
   if [[ "${retval}" -ne 0  ]]; then
     echo "Unable to upload ${signed_artifact} to BuildKite: error code '${retval}'"
     exit 6

--- a/hooks/command
+++ b/hooks/command
@@ -30,15 +30,7 @@ function fetch_artifact {
     exit 1
   fi
 
-  signing_target="$(pwd)/${fetch_target}"
-
-  # Remove this block once we're ready to start actually testing this in CI.
-  ### TESTING
-  # signing_target="$(pwd)/imp-ci"
-  # cp imp-ci-orig "${signing_target}"
-  ### TESTING
-
-  echo "${signing_target}"
+  echo "${dest_dir}/${fetch_target}"
 }
 
 # If the unlock secret was not supplied as an env var, call the helper script to fetch it
@@ -59,7 +51,6 @@ function get_keychain_pw {
 
 # Now unlock the keychain and find the identity to sign with
 function unlock_keychain {
-  echo "--- Unlocking the keychain"
   keychain_name=${1}
   keychain_pw=${2}
   security unlock-keychain -p "${keychain_pw}" "${keychain_name}"
@@ -99,7 +90,6 @@ function sign_and_validate {
 }
 
 function upload_artifact {
-  echo "--- Uploading signed artifact"
   signed_artifact="${1}"
   buildkite-agent artifact upload "${signed_artifact}"
   retval=$?
@@ -126,7 +116,10 @@ function find_keychain_pw_helper_script {
 echo "--- Getting the password to unlock the keychain"
 keychain_pw_helper_script=$(find_keychain_pw_helper_script)
 keychain_pw=$(get_keychain_pw "${keychain_pw_helper_script}" "${keychain_pw_name}")
+
+echo "--- Unlocking the keychain"
 unlock_keychain "${codesigning_keychain}" "${keychain_pw}"
+
 echo "--- Finding the code signing identity in the unlocked keychain"
 identity=$(get_signing_identity "${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN}")
 
@@ -137,7 +130,10 @@ artifacts_dir=$(mktemp -d)
 for artifact in $(plugin_read_list INPUT_ARTIFACTS) ; do
   echo "--- Retrieving unsigned artifact ${fetch_target}"
   unsigned_artifact="$(fetch_artifact ${artifact} ${artifacts_dir})"
+
   echo "--- Signing target binary"
   signed_artifact="$(sign_and_validate "${unsigned_artifact}" "${identity}")"
+
+  echo "--- Uploading signed artifact"
   upload_artifact "${unsigned_artifact}"
 done

--- a/hooks/command
+++ b/hooks/command
@@ -155,8 +155,8 @@ for artifact in $(plugin_read_list INPUT_ARTIFACTS) ; do
   # "signed/$BINARY_NAME"
   # Otherwise it gets the fully-qualified path to the artifact.  More like:
   # "usr/local/var/buildkite-agent/builds/macos-codesigner/improbable/platform-mac-codesign-test/signed/imp-ci"
-  signed_dir="$(dirname ${signed_artifact})/.."
-  signed_file="$(basename ${signed_artifact})/.."
+  signed_dir="$(dirname ${signed_artifact})"
+  signed_file="$(basename ${signed_artifact})"
   
   echo "--- ${signed_file}: uploading signed artifact"
   # Change to the directory containing "signed/", where the artifacts live.

--- a/hooks/command
+++ b/hooks/command
@@ -91,8 +91,11 @@ function sign_and_validate {
 
 function upload_artifact {
   signed_artifact="${1}"
-  buildkite-agent artifact upload "${signed_artifact}"
+  # The pushd/popd/dirname/basename shenanigans are so the artifact path in BK is friendlier
+  pushd $(dirname ${signed_artifact})
+  buildkite-agent artifact upload $(basename ${signed_artifact})
   retval=$?
+  popd
   if [[ "${retval}" -ne 0  ]]; then
     echo "Unable to upload ${signed_artifact} to BuildKite: error code '${retval}'"
     exit 6

--- a/hooks/command
+++ b/hooks/command
@@ -92,7 +92,8 @@ function sign_and_validate {
 function upload_artifact {
   signed_artifact="${1}"
   # The pushd/popd/dirname/basename shenanigans are so the artifact path in BK is friendlier
-  pushd $(dirname ${signed_artifact})
+  # eg "signed/$BINARY_NAME"
+  pushd "$(dirname ${signed_artifact})/.."
   buildkite-agent artifact upload $(basename ${signed_artifact})
   retval=$?
   popd

--- a/hooks/command
+++ b/hooks/command
@@ -91,7 +91,7 @@ function sign_and_validate {
 
 function upload_artifact {
   signed_artifact="${1}"
-  pushd "$(dirname ${signed_artifact})"
+  mv ${signed_artifact})
   buildkite-agent artifact upload "${signed_artifact}"
   retval=$?
   popd
@@ -125,17 +125,18 @@ unlock_keychain "${codesigning_keychain}" "${keychain_pw}"
 echo "--- Finding the code signing identity in the unlocked keychain"
 identity=$(get_signing_identity "${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN}")
 
-# Put all of the artifacts in a tempdir
-artifacts_dir=$(mktemp -d)
+# Sign things in a local dir so the uploaded artifacts don't have a weird path
+artifacts_dir="$(pwd)/signed"
+rm -rf "${artifacts_dir}" && mkdir -p "${artifacts_dir}"
 
 # Download and sign each requested artifact
 for artifact in $(plugin_read_list INPUT_ARTIFACTS) ; do
-  echo "--- Retrieving unsigned artifact ${fetch_target}"
+  echo "--- ${artifact}: retrieving unsigned artifact"
   unsigned_artifact="$(fetch_artifact ${artifact} ${artifacts_dir})"
 
-  echo "--- Signing target binary"
+  echo "--- ${artifact}: signing binary"
   signed_artifact="$(sign_and_validate "${unsigned_artifact}" "${identity}")"
 
-  echo "--- Uploading signed artifact"
+  echo "--- ${artifact}: uploading signed artifact"
   upload_artifact "${unsigned_artifact}"
 done

--- a/hooks/command
+++ b/hooks/command
@@ -6,22 +6,22 @@
 # 3. Unlock the keychain
 # 4. Sign the binary and validate the signature
 
+set -e -o pipefail
+[[ -n "${DEBUG-}" ]] && set -x
+
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
 # shellcheck source=lib/shared.sh
 source "${DIR}/../lib/shared.sh"
 
-[[ -n "${DEBUG-}" ]] && set -x
-
 keychain_pw_name="${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN_PW_SECRET_NAME}"
 script_root_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-default_keychain_pw_helper_script="${script_root_dir}/helpers/fetch-keychain-pw.sh"
+default_keychain_pw_helper_script="${script_root_dir}/../helpers/fetch-keychain-pw.sh"
 
 # Fetch the artifact and put it in the target dir
-func fetch_artifact() {
+function fetch_artifact {
   fetch_target="${1}"
   dest_dir="${2}"
-  echo "Retrieving unsigned artifact ${fetch_target}"
   buildkite-agent artifact download "${fetch_target}" "${dest_dir}"
   retval=$?
   if [[ "${retval}" -ne 0  ]]; then
@@ -33,15 +33,15 @@ func fetch_artifact() {
 
   # Remove this block once we're ready to start actually testing this in CI.
   ### TESTING
-  signing_target="$(pwd)/imp-ci"
-  cp imp-ci-orig "${signing_target}"
+  # signing_target="$(pwd)/imp-ci"
+  # cp imp-ci-orig "${signing_target}"
   ### TESTING
 
-  return "${signing_target}"
+  echo "${signing_target}"
 }
 
 # If the unlock secret was not supplied as an env var, call the helper script to fetch it
-func get_keychain_pw() {
+function get_keychain_pw {
   helper_script_path="${1}"
   helper_script_arg="${2}"
   if [[ -z "${KEYCHAIN_PW}" ]]; then
@@ -49,89 +49,94 @@ func get_keychain_pw() {
     retval=$?
     if [[ "${retval}" -ne 0 || -z "${KEYCHAIN_PW}"  ]]; then
       echo "Unable the fetch the secret using the helper script: error code '${retval}'"
-      exit 1
+      exit 2
     fi
   fi
 
-  return "${KEYCHAIN_PW}"
+  echo "${KEYCHAIN_PW}"
 }
 
 # Now unlock the keychain and find the identity to sign with
-func unlock_keychain() {
-  echo "Unlock the keychain"
+function unlock_keychain {
+  echo "--- Unlocking the keychain"
   keychain_name=${1}
   keychain_pw=${2}
   security unlock-keychain -p "${keychain_pw}" "${keychain_name}"
   retval=$?
   if [[ "${retval}" -ne 0  ]]; then
     echo "Unable to unlock the requested keychain '${keychain_name}': error code '${retval}'"
-    exit 1
+    exit 3
   fi
 }
 
-func get_signing_identity() {
-  echo "Find the code signing identity in the newly unlocked keychain"
+function get_signing_identity {
   # This is awful, but we need to get some portion of the identity out of the keychain, and there's no clean way to do it.
-  export CODESIGN_IDENTITY="$(security find-identity ${codesign_keychain} | grep -A1 "Valid identities" | tail -1 | awk '{print $2}')"
+  security find-identity ${codesign_keychain} | grep -A1 "Valid identities" | tail -1 | awk '{print $2}'
 }
 
 # Sign the binary
-func sign_and_validate() {
-  echo "Signing target binary"
-  codesign --verify --verbose --display --deep -s "${CODESIGN_IDENTITY}" "${signing_target}"
+function sign_and_validate {
+  signing_target="${1}"
+  identity="${2}"
+
+  codesign --verify --verbose --display --deep -s "${identity}" "${signing_target}"
   retval=$?
   if [[ "${retval}" -ne 0  ]]; then
     echo "codesigning of target '${signing_target}' failed: error code '${retval}'"
-    exit 2
+    exit 4
   fi
 
-  echo "Validating signature"
-  codesign --verify --deep --strict --verbose= "${signing_target}"
+  codesign --verify --deep --strict "${signing_target}"
   retval=$?
   if [[ "${retval}" -ne 0  ]]; then
     echo "Unable to verify that '${signing_target}' has a valid code signature: error code '${retval}'"
-    exit 3
+    exit 5
   fi
 
   # Copy the signed binary to where it's expected to be for artifact uploading.
   cp "${signing_target}" "${signing_target}_signed"
 }
 
-func upload_artifact() {
+function upload_artifact {
+  echo "--- Uploading signed artifact"
   signed_artifact="${1}"
   buildkite-agent artifact upload "${signed_artifact}"
   retval=$?
   if [[ "${retval}" -ne 0  ]]; then
     echo "Unable to upload ${signed_artifact} to BuildKite: error code '${retval}'"
-    exit 4
+    exit 6
   fi
 }
 
 # If the user set a secret-fetch helper script, use it, otherwise use the default.
-func find_keychain_pw_helper_script() {
-  if [[ -n "${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN_PW_HELPER_SCRIPT}"]]; then
+function find_keychain_pw_helper_script {
+  if [[ -n "${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN_PW_HELPER_SCRIPT}" ]]; then
     script="${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN_PW_HELPER_SCRIPT}"
   else
     script="${default_keychain_pw_helper_script}"
   fi
 
-  return "${script}"
+  echo "${script}"
 }
 
 ## Main execution flow
 
 # Set everything up to be able to sign.
+echo "--- Getting the password to unlock the keychain"
 keychain_pw_helper_script=$(find_keychain_pw_helper_script)
 keychain_pw=$(get_keychain_pw "${keychain_pw_helper_script}" "${keychain_pw_name}")
 unlock_keychain "${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN}" "${KEYCHAIN_PW}"
-get_signing_identity "${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN}"
+echo "--- Finding the code signing identity in the unlocked keychain"
+identity=$(get_signing_identity "${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN}")
 
 # Put all of the artifacts in a tempdir
 artifacts_dir=$(mktemp -d)
 
 # Download and sign each requested artifact
 for artifact in $(plugin_read_list INPUT_ARTIFACTS) ; do
+  echo "--- Retrieving unsigned artifact ${fetch_target}"
   unsigned_artifact="$(fetch_artifact ${artifact} ${artifacts_dir})"
-  signed_artifact="$(sign_and_validate "${unsigned_artifact}")"
+  echo "--- Signing target binary"
+  signed_artifact="$(sign_and_validate "${unsigned_artifact}" "${identity}")"
   upload_artifact "${unsigned_artifact}"
 done

--- a/hooks/command
+++ b/hooks/command
@@ -86,7 +86,9 @@ function sign_and_validate {
   fi
 
   # Copy the signed binary to where it's expected to be for artifact uploading.
-  cp "${signing_target}" "${signing_target}_signed"
+  signed_artifact="${signing_target}_signed"
+  cp "${signing_target}" "${signed_artifact}"
+  echo "${signed_artifact}"
 }
 
 function upload_artifact {
@@ -128,17 +130,17 @@ echo "--- Finding the code signing identity in the unlocked keychain"
 identity=$(get_signing_identity "${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN}")
 
 # Sign things in a local dir so the uploaded artifacts don't have a weird path
-artifacts_dir="$(pwd)/signed"
-rm -rf "${artifacts_dir}" && mkdir -p "${artifacts_dir}"
+relative_artifacts_dir="$(pwd)/signed"
+rm -rf "${relative_artifacts_dir}" && mkdir -p "${relative_artifacts_dir}"
 
 # Download and sign each requested artifact
 for artifact in $(plugin_read_list INPUT_ARTIFACTS) ; do
   echo "--- ${artifact}: retrieving unsigned artifact"
-  unsigned_artifact="$(fetch_artifact ${artifact} ${artifacts_dir})"
+  unsigned_artifact="$(fetch_artifact ${artifact} ${relative_artifacts_dir})"
 
   echo "--- ${artifact}: signing binary"
   signed_artifact="$(sign_and_validate "${unsigned_artifact}" "${identity}")"
 
   echo "--- ${artifact}: uploading signed artifact"
-  upload_artifact "${unsigned_artifact}"
+  upload_artifact "${signed_artifact}"
 done

--- a/hooks/command
+++ b/hooks/command
@@ -91,7 +91,7 @@ function sign_and_validate {
 
 function upload_artifact {
   signed_artifact="${1}"
-  pushd "$(basename ${signed_artifact})"
+  pushd "$(dirname ${signed_artifact})"
   buildkite-agent artifact upload "${signed_artifact}"
   retval=$?
   popd

--- a/hooks/command
+++ b/hooks/command
@@ -15,6 +15,7 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 source "${DIR}/../lib/shared.sh"
 
 keychain_pw_name="${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN_PW_SECRET_NAME}"
+codesigning_keychain="${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN}"
 script_root_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 default_keychain_pw_helper_script="${script_root_dir}/../helpers/fetch-keychain-pw.sh"
 
@@ -45,7 +46,7 @@ function get_keychain_pw {
   helper_script_path="${1}"
   helper_script_arg="${2}"
   if [[ -z "${KEYCHAIN_PW}" ]]; then
-    "$(${helper_script_path} ${helper_script_arg})"
+    KEYCHAIN_PW="$(${helper_script_path} ${helper_script_arg})"
     retval=$?
     if [[ "${retval}" -ne 0 || -z "${KEYCHAIN_PW}"  ]]; then
       echo "Unable the fetch the secret using the helper script: error code '${retval}'"
@@ -125,7 +126,7 @@ function find_keychain_pw_helper_script {
 echo "--- Getting the password to unlock the keychain"
 keychain_pw_helper_script=$(find_keychain_pw_helper_script)
 keychain_pw=$(get_keychain_pw "${keychain_pw_helper_script}" "${keychain_pw_name}")
-unlock_keychain "${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN}" "${KEYCHAIN_PW}"
+unlock_keychain "${codesigning_keychain}" "${keychain_pw}"
 echo "--- Finding the code signing identity in the unlocked keychain"
 identity=$(get_signing_identity "${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN}")
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -33,8 +33,7 @@ if [[ "${BUILDKITE_AGENT_META_DATA_PLATFORM}" != "macos" ]]; then
   exit 4
 fi
 
-# This var doesn't seem to be set.  Will address later.
-# if [[ "${BUILDKITE_AGENT_META_DATA_HOSTNAME}" != "${permitted_signing_host}" ]]; then
-#   echo "Host ${BUILDKITE_AGENT_META_DATA_HOSTNAME} is not permitted to do code-signing."
-#   exit 5
-# fi
+if [[ "${BUILDKITE_AGENT_META_DATA_HOSTNAME}" != "${permitted_signing_host}" ]]; then
+  echo "Host ${BUILDKITE_AGENT_META_DATA_HOSTNAME} is not permitted to do code-signing."
+  exit 5
+fi

--- a/hooks/environment
+++ b/hooks/environment
@@ -29,8 +29,14 @@ if [[ "${BUILDKITE_SOURCE}" == "local" ]]; then
   # exit 3
 fi
 
-if [[ "${BUILDKITE_AGENT_META_DATA_PLATFORM}" != "macos" ]]; then
-  echo "Code signing of macOS binaries can only be performed on macos, not ${BUILDKITE_AGENT_META_DATA_PLATFORM}."
+# Not sure why thuis doesn't work in bk local.
+# if [[ "${BUILDKITE_AGENT_META_DATA_PLATFORM}" != "macos" ]]; then
+#   echo "Code signing of macOS binaries can only be performed on macos, not ${BUILDKITE_AGENT_META_DATA_PLATFORM}."
+#   exit 4
+# fi
+
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "Code signing of macOS binaries can only be performed on macos, not $(uname)."
   exit 4
 fi
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -30,11 +30,11 @@ if [[ "${BUILDKITE_SOURCE}" == "local" ]]; then
 fi
 
 if [[ "${BUILDKITE_AGENT_META_DATA_PLATFORM}" != "macos" ]]; then
-  echo "Code signing of macOS binaries can only be performed on macos."
+  echo "Code signing of macOS binaries can only be performed on macos, not ${BUILDKITE_AGENT_META_DATA_PLATFORM}."
   exit 4
 fi
 
 if [[ "${BUILDKITE_AGENT_META_DATA_HOSTNAME}" != "${permitted_signing_host}" ]]; then
-  echo "Code signing can only be performed on specific permitted agents."
+  echo "Host ${BUILDKITE_AGENT_META_DATA_HOSTNAME} is not permitted to do code-signing."
   exit 5
 fi

--- a/hooks/environment
+++ b/hooks/environment
@@ -23,24 +23,19 @@ if [[ "${BUILDKITE}" != "true" ]]; then
   exit 2
 fi
 
+# Commented out temporarily for local testing.
 if [[ "${BUILDKITE_SOURCE}" == "local" ]]; then
   echo "Code signing is not allowed to be done locally."
-  # Commented out temporarily for local testing.
-  # exit 3
+  exit 3
 fi
 
-# Not sure why thuis doesn't work in bk local.
+# Not sure why these don't work in bk local.
 # if [[ "${BUILDKITE_AGENT_META_DATA_PLATFORM}" != "macos" ]]; then
 #   echo "Code signing of macOS binaries can only be performed on macos, not ${BUILDKITE_AGENT_META_DATA_PLATFORM}."
 #   exit 4
 # fi
 
-if [[ "$(uname)" != "Darwin" ]]; then
-  echo "Code signing of macOS binaries can only be performed on macos, not $(uname)."
-  exit 4
-fi
-
-if [[ "${BUILDKITE_AGENT_META_DATA_HOSTNAME}" != "${permitted_signing_host}" ]]; then
-  echo "Host ${BUILDKITE_AGENT_META_DATA_HOSTNAME} is not permitted to do code-signing."
-  exit 5
-fi
+# if [[ "${BUILDKITE_AGENT_META_DATA_HOSTNAME}" != "${permitted_signing_host}" ]]; then
+#   echo "Host ${BUILDKITE_AGENT_META_DATA_HOSTNAME} is not permitted to do code-signing."
+#   exit 5
+# fi

--- a/hooks/environment
+++ b/hooks/environment
@@ -25,7 +25,8 @@ fi
 
 if [[ "${BUILDKITE_SOURCE}" == "local" ]]; then
   echo "Code signing is not allowed to be done locally."
-  exit 3
+  # Commented out temporarily for local testing.
+  # exit 3
 fi
 
 if [[ "${BUILDKITE_AGENT_META_DATA_PLATFORM}" != "macos" ]]; then

--- a/hooks/environment
+++ b/hooks/environment
@@ -24,18 +24,18 @@ if [[ "${BUILDKITE}" != "true" ]]; then
 fi
 
 # Commented out temporarily for local testing.
-# if [[ "${BUILDKITE_SOURCE}" == "local" ]]; then
-#   echo "Code signing is not allowed to be done locally."
-#   exit 3
-# fi
+if [[ "${BUILDKITE_SOURCE}" == "local" ]]; then
+  echo "Code signing is not allowed to be done locally."
+  exit 3
+fi
 
-# Not sure why these don't work in bk local.
-# if [[ "${BUILDKITE_AGENT_META_DATA_PLATFORM}" != "macos" ]]; then
-#   echo "Code signing of macOS binaries can only be performed on macos, not ${BUILDKITE_AGENT_META_DATA_PLATFORM}."
-#   exit 4
-# fi
+Not sure why these don't work in bk local.
+if [[ "${BUILDKITE_AGENT_META_DATA_PLATFORM}" != "macos" ]]; then
+  echo "Code signing of macOS binaries can only be performed on macos, not ${BUILDKITE_AGENT_META_DATA_PLATFORM}."
+  exit 4
+fi
 
-# if [[ "${BUILDKITE_AGENT_META_DATA_HOSTNAME}" != "${permitted_signing_host}" ]]; then
-#   echo "Host ${BUILDKITE_AGENT_META_DATA_HOSTNAME} is not permitted to do code-signing."
-#   exit 5
-# fi
+if [[ "${BUILDKITE_AGENT_META_DATA_HOSTNAME}" != "${permitted_signing_host}" ]]; then
+  echo "Host ${BUILDKITE_AGENT_META_DATA_HOSTNAME} is not permitted to do code-signing."
+  exit 5
+fi

--- a/hooks/environment
+++ b/hooks/environment
@@ -24,10 +24,10 @@ if [[ "${BUILDKITE}" != "true" ]]; then
 fi
 
 # Commented out temporarily for local testing.
-if [[ "${BUILDKITE_SOURCE}" == "local" ]]; then
-  echo "Code signing is not allowed to be done locally."
-  exit 3
-fi
+# if [[ "${BUILDKITE_SOURCE}" == "local" ]]; then
+#   echo "Code signing is not allowed to be done locally."
+#   exit 3
+# fi
 
 # Not sure why these don't work in bk local.
 # if [[ "${BUILDKITE_AGENT_META_DATA_PLATFORM}" != "macos" ]]; then

--- a/hooks/environment
+++ b/hooks/environment
@@ -23,13 +23,11 @@ if [[ "${BUILDKITE}" != "true" ]]; then
   exit 2
 fi
 
-# Commented out temporarily for local testing.
 if [[ "${BUILDKITE_SOURCE}" == "local" ]]; then
   echo "Code signing is not allowed to be done locally."
   exit 3
 fi
 
-Not sure why these don't work in bk local.
 if [[ "${BUILDKITE_AGENT_META_DATA_PLATFORM}" != "macos" ]]; then
   echo "Code signing of macOS binaries can only be performed on macos, not ${BUILDKITE_AGENT_META_DATA_PLATFORM}."
   exit 4

--- a/hooks/environment
+++ b/hooks/environment
@@ -11,7 +11,8 @@ permitted_signing_host="sean-mac-c02xv3a8jgh6"
 codesign_keychain="${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN}"
 pw_secret="${BUILDKITE_PLUGIN_MAC_CODESIGN_SIGNING_CERT_PW_SECRET}"
 
-if [[ ! security list-keychains ]]; then
+security list-keychains | grep "${codesign_keychain}" > /dev/null
+if [[ $? -ne 0 || -z "${codesign_keychain}" ]]; then
   echo "Unable to find/read specified signing keychain ${codesign_keychain}"
   exit 1
 fi

--- a/hooks/environment
+++ b/hooks/environment
@@ -33,7 +33,8 @@ if [[ "${BUILDKITE_AGENT_META_DATA_PLATFORM}" != "macos" ]]; then
   exit 4
 fi
 
-if [[ "${BUILDKITE_AGENT_META_DATA_HOSTNAME}" != "${permitted_signing_host}" ]]; then
-  echo "Host ${BUILDKITE_AGENT_META_DATA_HOSTNAME} is not permitted to do code-signing."
-  exit 5
-fi
+# This var doesn't seem to be set.  Will address later.
+# if [[ "${BUILDKITE_AGENT_META_DATA_HOSTNAME}" != "${permitted_signing_host}" ]]; then
+#   echo "Host ${BUILDKITE_AGENT_META_DATA_HOSTNAME} is not permitted to do code-signing."
+#   exit 5
+# fi

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -8,6 +8,7 @@
 rm -f "${BUILDKITE_PLUGIN_MAC_CODESIGN_INPUT_ARTIFACT}"
 
 # And lock the door behind us
+echo "--- Locking signing keychain"
 security lock-keychain "${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN}"
 
 if [[ $? -ne 0 ]]; then

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -15,5 +15,5 @@ if [[ $? -ne 0 ]]; then
   # TODO: This needs to be able to actually alert us directly if it happens.
   echo "ERROR: Unable to lock codesigning keychain!"
   echo "This can be extremely serious!  Let #eng-velocity know right away!"
-  exit 5 # Arbitrary error exit code for this specific condition.
+  exit 15 # Arbitrary error exit code for this specific condition.
 fi


### PR DESCRIPTION
https://buildkite.com/improbable/platform-mac-codesign-test/builds/22 is a fully working end-to-end signing job.  The step definition used to create this was:

```yaml
- label: "sign-binary"
    plugins:
    - improbable-eng/mac-codesign#bc0cabd:
        input_artifacts:
          - "imp-ci"
          - "imp-vault"
        keychain: "test-codesigning.keychain"
        keychain_pw_secret_name: "ci/improbable/test-codesign-plugin"
    <<: *common # This just includes the agent targeting parameters
```