### PR TITLE
access is locked down to specific path and service account

### DIFF
--- a/helpers/fetch-keychain-pw.sh
+++ b/helpers/fetch-keychain-pw.sh
@@ -6,7 +6,7 @@
 [[ -n "${DEBUG-}" ]] && set -x
 
 # All decryption password secrets must live under this path
-keychain_pw_root="secret/sync.v1/dev-workflow/production-buildkite/buildkite-agents/cert-decryption-password/"
+keychain_pw_root="secret/sync.v1/dev-workflow/production-buildkite/code-signing/cert-decryption-password"
 keychain_pw_name="${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN_PW_SECRET_NAME}"
 keychain_pw_path="${keychain_pw_root}/${keychain_pw_name}"
 


### PR DESCRIPTION
Our vault config has changed to further lockdown the usage of codesigning to only a few engineers and CI agents.

Other relevant PR: https://github.com/improbable/platform/pull/20477
