### PR TITLE
Bug - Zip step fails to run due to missing arguments

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -142,6 +142,11 @@ function sign_code() {
   generate_signing_config "${prerequisites}" "${entitlements}" "${artifact_dir}" "${config_path}"
 
   echo "--- Signing and notarizing"
+  ls -hal
+  echo "test end here"
+  echo $base_artifact
+  echo $signed_dir_fragment
+  echo $signed_artifact
   gon "${config_path}"
 }
 
@@ -252,11 +257,6 @@ else
   if [[ "${base_artifact}" == *".zip" ]]; then
     # move to dir to avoid weird paths in the zip
     pushd "${signed_dir_fragment}"
-    ls -hal
-    echo "test end here"
-    echo $base_artifact
-    echo $signed_dir_fragment
-    echo $signed_artifact
     echo "--- Zipping signed artifact"
     # -1 for speed
     # -y to preserve symlinks

--- a/hooks/command
+++ b/hooks/command
@@ -17,15 +17,7 @@ source "${DIR}/../lib/shared.sh"
 codesigning_keychain="${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN}"
 script_root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 default_keychain_pw_helper_script="${script_root_dir}/../helpers/fetch-keychain-pw.sh"
-function debug() {
-   echo "ls: $(ls -hal)"
-   echo "pwd: $(pwd)"
-   echo "base_artifact: ${base_artifact}"
-   echo "ls signed: $(ls -hal signed/)"
-   echo "signed_artifact: $(signed_artifact)"
-   echo "unsigned_artifact: $(unsigned_artifact)"
 
-}
 # Fetch the artifact and put it in the target dir
 # Params:
 #   fetch_target: Name of the BuildKite artifact to fetch
@@ -260,7 +252,6 @@ else
   if [[ "${base_artifact}" == *".zip" ]]; then
     # move to dir to avoid weird paths in the zip
     pushd "${signed_dir_fragment}"
-    debug
     echo "--- Zipping signed artifact"
     # -1 for speed
     # -y to preserve symlinks

--- a/hooks/command
+++ b/hooks/command
@@ -20,7 +20,8 @@ default_keychain_pw_helper_script="${script_root_dir}/../helpers/fetch-keychain-
 function debug() {
    echo "ls: $(ls -hal)"
    echo "pwd: $(pwd)"
-   echo
+   echo "base_artifact: ${base_artifact}"
+   echo "ls signed: $(ls -hal signed/)"
 }
 # Fetch the artifact and put it in the target dir
 # Params:

--- a/hooks/command
+++ b/hooks/command
@@ -142,11 +142,6 @@ function sign_code() {
   generate_signing_config "${prerequisites}" "${entitlements}" "${artifact_dir}" "${config_path}"
 
   echo "--- Signing and notarizing"
-  ls -hal
-  echo "test end here"
-  echo $base_artifact
-  echo $signed_dir_fragment
-  echo $signed_artifact
   gon "${config_path}"
 }
 
@@ -257,6 +252,9 @@ else
   if [[ "${base_artifact}" == *".zip" ]]; then
     # move to dir to avoid weird paths in the zip
     pushd "${signed_dir_fragment}"
+    echo "pwd: $(pwd)"
+    echo "ls: $(ls -hal)"
+    echo "ls ..: $(ls -hal ..)"
     echo "--- Zipping signed artifact"
     # -1 for speed
     # -y to preserve symlinks

--- a/hooks/command
+++ b/hooks/command
@@ -252,6 +252,11 @@ else
   if [[ "${base_artifact}" == *".zip" ]]; then
     # move to dir to avoid weird paths in the zip
     pushd "${signed_dir_fragment}"
+    ls -hal
+    echo "test end here"
+    echo $base_artifact
+    echo $signed_dir_fragment
+    echo $signed_artifact
     echo "--- Zipping signed artifact"
     # -1 for speed
     # -y to preserve symlinks

--- a/hooks/command
+++ b/hooks/command
@@ -22,6 +22,9 @@ function debug() {
    echo "pwd: $(pwd)"
    echo "base_artifact: ${base_artifact}"
    echo "ls signed: $(ls -hal signed/)"
+   echo "signed_artifact: $(signed_artifact)"
+   echo "unsigned_artifact: $(unsigned_artifact)"
+
 }
 # Fetch the artifact and put it in the target dir
 # Params:
@@ -263,7 +266,7 @@ else
     # -y to preserve symlinks
     # -r for directories
     # -X to remove .DS_STORE etc
-    zip -1 -y -r -X "${base_artifact}"
+    zip -1 -y -r -X "${base_artifact}" ${base_artifact::-4}
     popd
   else
     # Codesign is in place, so move to signed location

--- a/hooks/command
+++ b/hooks/command
@@ -17,7 +17,11 @@ source "${DIR}/../lib/shared.sh"
 codesigning_keychain="${BUILDKITE_PLUGIN_MAC_CODESIGN_KEYCHAIN}"
 script_root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 default_keychain_pw_helper_script="${script_root_dir}/../helpers/fetch-keychain-pw.sh"
-
+function debug() {
+   echo "ls: $(ls -hal)"
+   echo "pwd: $(pwd)"
+   echo
+}
 # Fetch the artifact and put it in the target dir
 # Params:
 #   fetch_target: Name of the BuildKite artifact to fetch
@@ -252,9 +256,7 @@ else
   if [[ "${base_artifact}" == *".zip" ]]; then
     # move to dir to avoid weird paths in the zip
     pushd "${signed_dir_fragment}"
-    echo "pwd: $(pwd)"
-    echo "ls: $(ls -hal)"
-    echo "ls ..: $(ls -hal ..)"
+    debug
     echo "--- Zipping signed artifact"
     # -1 for speed
     # -y to preserve symlinks


### PR DESCRIPTION
Zip requires `zip <output> <input>` in order to work. Our recent refactor adding zip support failed to capture this bug.