### PR TITLE
Fix path errors caused by possibly inconsistent filenames when using zip files

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -242,17 +242,13 @@ if [[ "${base_artifact}" == *".pkg" ]]; then
   echo "--- Signing PKG artifact"
   sign_pkg "${unsigned_artifact}" "${signed_artifact}" "${config_path}"
 else
-  path_to_sign="${signed_dir_fragment}"
-
   if [[ "${base_artifact}" == *".zip" ]]; then
-    # unzip into a relevant directory
-    path_to_sign="${signed_dir_fragment}/${base_artifact_no_extension}"
-    echo "--- Unzipping downloaded artifact to ${path_to_sign}"
-    unzip "${unsigned_artifact}" -d "${path_to_sign}"
+    echo "--- Unzipping downloaded artifact to ${signed_dir_fragment}"
+    unzip "${unsigned_artifact}" -d "${signed_dir_fragment}"
   fi
 
-  echo "--- Signing artifact: ${path_to_sign}"
-  sign_code "${path_to_sign}" "${config_path}" "${prerequisites}" "${entitlements}"
+  echo "--- Signing artifact: ${signed_artifact}"
+  sign_code "${signed_dir_fragment}" "${config_path}" "${prerequisites}" "${entitlements}"
 
   if [[ "${base_artifact}" == *".zip" ]]; then
     # move to dir to avoid weird paths in the zip
@@ -262,7 +258,8 @@ else
     # -y to preserve symlinks
     # -r for directories
     # -X to remove .DS_STORE etc
-    zip -1 -y -r -X "${base_artifact}" "${base_artifact_no_extension}"
+    # We are in a clean signed dir, so select all directories (also avoids path mangling)
+    zip -1 -y -r -X "${base_artifact}" ./*
     popd
   else
     # Codesign is in place, so move to signed location

--- a/hooks/command
+++ b/hooks/command
@@ -220,7 +220,6 @@ fi
 
 unsigned_artifact="${artifact_dir_fragment}/${artifact}"
 base_artifact="$(basename "${artifact}")"
-base_artifact_no_extension="${base_artifact%.*}"
 signed_artifact="${signed_dir_fragment}/${base_artifact}"
 
 # Make sure dir structure exists

--- a/hooks/command
+++ b/hooks/command
@@ -220,6 +220,7 @@ fi
 
 unsigned_artifact="${artifact_dir_fragment}/${artifact}"
 base_artifact="$(basename "${artifact}")"
+base_artifact_no_extension="${base_artifact%.*}"
 signed_artifact="${signed_dir_fragment}/${base_artifact}"
 
 # Make sure dir structure exists
@@ -233,7 +234,7 @@ if [[ -z "${prerequisites}" ]]; then
   prerequisites="${unsigned_artifact}"
 fi
 
-echo "--- Signing artifact"
+echo "--- Preparing to sign artifact: ${unsigned_artifact}"
 if [[ "${base_artifact}" == *".pkg" ]]; then
   # PKG files need to be signed with "Developer ID Installer" certs through `productsign`.
   # `gon` only supports "Application" certs, through `codesign`.
@@ -241,13 +242,17 @@ if [[ "${base_artifact}" == *".pkg" ]]; then
   echo "--- Signing PKG artifact"
   sign_pkg "${unsigned_artifact}" "${signed_artifact}" "${config_path}"
 else
+  path_to_sign="${signed_dir_fragment}"
+
   if [[ "${base_artifact}" == *".zip" ]]; then
-    echo "--- Unzipping downloaded artifact"
-    unzip "${unsigned_artifact}" -d "${signed_dir_fragment}"
+    # unzip into a relevant directory
+    path_to_sign="${signed_dir_fragment}/${base_artifact_no_extension}"
+    echo "--- Unzipping downloaded artifact to ${path_to_sign}"
+    unzip "${unsigned_artifact}" -d "${path_to_sign}"
   fi
 
-  echo "--- Signing artifact"
-  sign_code "${signed_dir_fragment}" "${config_path}" "${prerequisites}" "${entitlements}"
+  echo "--- Signing artifact: ${path_to_sign}"
+  sign_code "${path_to_sign}" "${config_path}" "${prerequisites}" "${entitlements}"
 
   if [[ "${base_artifact}" == *".zip" ]]; then
     # move to dir to avoid weird paths in the zip
@@ -257,7 +262,7 @@ else
     # -y to preserve symlinks
     # -r for directories
     # -X to remove .DS_STORE etc
-    zip -1 -y -r -X "${base_artifact}" ${base_artifact::-4}
+    zip -1 -y -r -X "${base_artifact}" "${base_artifact_no_extension}"
     popd
   else
     # Codesign is in place, so move to signed location


### PR DESCRIPTION
Unexpected path names are causing failures to upload the signed output.
This PR standardises that output by using the zip archive name with no extension as the zip output dir.